### PR TITLE
use Amplify Auth federatedSignIn() for logging users in

### DIFF
--- a/services/ui-src/src/App.js
+++ b/services/ui-src/src/App.js
@@ -55,11 +55,7 @@ function App() {
         loginLocalUser(alice);
         userHasAuthenticated(true);
       } else {
-        const authConfig = Auth.configure();
-        const { domain, redirectSignIn, responseType } = authConfig.oauth;
-        const clientId = authConfig.userPoolWebClientId;
-        const url = `https://${domain}/oauth2/authorize?redirect_uri=${redirectSignIn}&response_type=${responseType}&client_id=${clientId}`;
-        window.location.assign(url);
+        Auth.federatedSignIn();
       }
     } catch (e) {
       onError(e);

--- a/services/ui-src/src/index.js
+++ b/services/ui-src/src/index.js
@@ -19,7 +19,7 @@ Amplify.configure({
       domain: config.cognito.APP_CLIENT_DOMAIN,
       redirectSignIn: config.cognito.REDIRECT_SIGNIN,
       redirectSignOut: config.cognito.REDIRECT_SIGNOUT,
-      scope: ["email", "openid"],
+      scope: ["email", "openid", "aws.cognito.signin.user.admin"],
       responseType: "code",
     },
   },


### PR DESCRIPTION
This method uses OAuth2 code grant flow with PKCE extension which is a best practice for using OAuth2 with Single-Page Apps.
It adds a scope to the Amplify Auth config to be consistent with the serverless.yml config, which also lists OAuth2 scopes for the app.

Tested:
1. deployed stage to AWS and created a verified user in the user pool
logged in as user with Dev Tools and verified that the PKCE extension is part of the OAuth2 code grant flow

2. deployed React front-end locally and verified app works as expected

## Purpose
Use OAuth2 with PKCE extension with Cognito Hosted UI.
Code changes needed to support a 3rd-party Identity Provider, such as Okta, will be included in a separated PR.

#### Linked Issues to Close
https://jiraent.cms.gov/browse/CMCSMACD-536

## Learning
The research I did for this PR is documented [here](https://confluenceent.cms.gov/x/Od2fEw).

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and its links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as a reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
